### PR TITLE
Update dot_driver.c compile prototype error macOS

### DIFF
--- a/src/k_aug/dot_driver.c
+++ b/src/k_aug/dot_driver.c
@@ -25,5 +25,5 @@
 #include <stdlib.h>
 
 
-void fun_name(){}
+void fun_name(void){}
 


### PR DESCRIPTION
Fix error building k_aug

```
[ 25%] Building C object CMakeFiles/k_aug.dir/src/k_aug/dot_driver.c.o
/Users/johneslick/src/idaes-ext-build/k_aug/src/k_aug/dot_driver.c:28:14: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
void fun_name(){}
             ^
              void
1 error generated.
```